### PR TITLE
fix migrate:rollback on localhost

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,6 +38,8 @@ class ServiceProvider extends BaseServiceProvider
     {
         if (!$this->isLumen()) {
             $this->publishes([$this->configPath() => config_path('audit.php')]);
+        } else {
+            $this->app->configure('audit');
         }
 
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');


### PR DESCRIPTION
При выполнении миграций добавляется migrate 2020_02_01_000000_create_audits_table, но у нас уже есть миграция create_audits_table. И если сделать php artisan migrate:rollback, то выдает ошибку. create_audits_table уже существует.